### PR TITLE
scvi-tools 1.1.6 requires lightning<2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   script: '{{ PYTHON }} -m pip install . -vv '
 
 requirements:
@@ -28,7 +28,7 @@ requirements:
     - openpyxl >=3.0
     - pandas >=1.0
     - pyro-ppl >=1.6.0
-    - lightning >=2.0
+    - lightning >=2.0,<2.2
     - rich >=12.0.0
     - scikit-learn >=0.21.2
     - pytorch >=1.8.0
@@ -55,7 +55,10 @@ test:
     - scvi.data
     - scvi.distributions
   requires:
+    - pip
     - pytest
+  commands:
+    - pip check
 
 about:
   home: https://scvi-tools.org/


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

---

scvi-tools 1.1.6 build number 1 from conda-forge has incorrect metadata because it removed the upper bound on lightning (https://github.com/conda-forge/scvi-tools-feedstock/pull/52), which still exists in the PyPI package, thus producing a broken conda env.

This PR fixes the recipe by adding back the upper bound. I also added `pip check` to the test section to catch these types of problems in the future. I will also submit a repodata patch to fix the metadata for build number 1.

Going forward, the upper bound cannot be removed from the recipe until the next PyPI release of scvi-tools (https://github.com/scverse/scvi-tools/issues/2967)

xref: https://github.com/conda-forge/scvi-tools-feedstock/issues/54