### PR TITLE
Add upper bound anndata<=0.10.8

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,6 @@
 conda_forge_output_validation: true
 bot:
-  automerge: true
+  automerge: false
 github:
   branch_name: main
   tooling_branch_name: main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: '{{ PYTHON }} -m pip install . -vv '
 
 requirements:
@@ -21,7 +21,7 @@ requirements:
     - pip >=22.0
   run:
     - python >=3.9
-    - anndata >=0.7.5
+    - anndata >=0.7.5,<=0.10.8
     - docrep >=0.3.2
     - h5py >=2.9.0
     - numpy >=1.17.0
@@ -55,7 +55,10 @@ test:
     - scvi.data
     - scvi.distributions
   requires:
+    - pip
     - pytest
+  commands:
+    - pip check
 
 about:
   home: https://scvi-tools.org/


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering) (**Note:** rerendering locally had no effect since it was just rerendered yesterday)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

---

Background:

* scvi-tools 1.1.6.post2 added the upper bound anndata<=0.10.8 (https://github.com/scverse/scvi-tools/pull/2971)
* The 1.1.6.post2 bot PR was automerged without updating the conda recipe (https://github.com/conda-forge/scvi-tools-feedstock/pull/57#issuecomment-2353371071)

xref: https://github.com/scverse/scvi-tools/issues/2967#issuecomment-2353359141

This PR:

* adds the anndata upper bound
* adds a `pip check` to catch these types of dependency problems earlier
* disables the bot automerges. The scvi-tools package has regularly changing lower and upper bounds. It is worth a maintainer taking a glance at the changelog to check for any updated dependencies prior to merging the PR since updating the dependencies pre-merge is easier than fixing them post-merge (which requires not only a follow-up PR like this one but also a repodata patch)