### PR TITLE
Fix lint: Add Python build backend hatchling to host requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ build:
 requirements:
   host:
     - python {{ python_min }}
+    - hatchling
     - hatch
     - pip >=22.0
   run:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

Fixed the current lint:

```sh
conda smithy lint --conda-forge recipe/
## recipe/ has some suggestions:
##   No valid build backend found for Python recipe for package `scvi-tools` using `pip`. Python recipes using `pip` need to explicitly specify a build backend in the `host` section. If your recipe has built with only `pip` in the `host` section in the past, you likely should add `setuptools` to the `host` section of your recipe.
##   `noarch: python` recipes should usually follow the syntax in our [documentation](https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-python) for specifying the Python version.
##    - For the `host` section of the recipe, you should usually use `python {{ python_min }}` for the `python` entry.
##    - For the `run` section of the recipe, you should usually use `python >={{ python_min }}` for the `python` entry.
##    - For the `test.requires` section of the recipe, you should usually use `python {{ python_min }}` for the `python` entry.
##    - If the package requires a newer Python version than the currently supported minimum version on `conda-forge`, you can override the `python_min` variable by adding a Jinja2 `set` statement at the top of your recipe (or using an equivalent `context` variable for v1 recipes).
```

* Added `hatchling` as Python build backend (for more details see https://github.com/conda-forge/scvi-tools-feedstock/pull/59#issuecomment-2377373103)
* ~~Added [new `python_min` syntax](https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-python) to ensure minimum Python version for noarch recipes~~ Done in #64 
* Didn't bother bumping the build number. We just uploaded a new binary earlier today from #60 (**update:** now #64). These changes are more for long-term recipe maintenance and don't have any immediate effect on the conda binary produced